### PR TITLE
Update dcgm-exporter github repo hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ NVIDIA Data Center GPU Manager (DCGM) is a suite of tools for managing and monit
 
 DCGM simplifies GPU administration in the data center, improves resource reliability and uptime, automates administrative tasks, and helps drive overall infrastructure efficiency. DCGM supports Linux operating systems on x86_64, Arm and POWER (ppc64le) platforms. The installer packages include libraries, binaries, NVIDIA Validation Suite (NVVS) and source examples for using the API (C, Python and Go).
 
-DCGM integrates into the Kubernetes ecosystem by allowing users to gather GPU telemetry using [dcgm-exporter](https://github.com/NVIDIA/gpu-monitoring-tools).
+DCGM integrates into the Kubernetes ecosystem by allowing users to gather GPU telemetry using [dcgm-exporter](https://github.com/NVIDIA/dcgm-exporter).
 
 More information is available on [DCGM's official page](https://developer.nvidia.com/dcgm)
 


### PR DESCRIPTION
## Why this PR?

fixes #25  
To update the hyperlink of dcgm-exporter in README which currently points to archived repository.

## What's changed?

- Updated `README.md` with the new hyperlink. https://github.com/NVIDIA/dcgm-exporter