### PR TITLE
common/DCGMStringHelpers: use memccpy for performance & error handling

### DIFF
--- a/common/DcgmStringHelpers.cpp
+++ b/common/DcgmStringHelpers.cpp
@@ -57,10 +57,15 @@ std::vector<std::string> dcgmTokenizeString(const std::string &src, const std::s
 }
 
 /*****************************************************************************/
-void dcgmStrncpy(char *destination, const char *source, size_t destinationSize)
+bool dcgmStrncpy(char *destination, const char *source, size_t destinationSize)
 {
-    strncpy(destination, source, destinationSize);
-    destination[destinationSize - 1] = '\0';
+    if (nullptr == static_cast<char*>(memccpy(destination, source, '\0', destinationSize)))
+    {
+        destination[destinationSize - 1] = '\0';
+        return false;
+    }
+
+    return true;
 }
 
 namespace DcgmNs

--- a/common/DcgmStringHelpers.h
+++ b/common/DcgmStringHelpers.h
@@ -49,12 +49,20 @@ std::vector<std::string> dcgmTokenizeString(const std::string &src, const std::s
  * Unlike strncpy(), This version actually NULL-terminates destionation
  * if source is >= (destinationSize+1) in length.
  *
+ * Unlike strncpy(), This version will now inform you if you attempt to 
+ * copy a source that is larger than the destination buffer.
+ * 
+ * Unlike strncpy(), If the source is shorter than the destination size
+ * this implementation will immediately stop once the null terminating 
+ * string is encountered. Unlike its strncpy counterpart which will append
+ * null bytes until n bytes (destinationSize) are written.
+ * 
  * destination    OUT: Destination buffer
  * source          IN: Source NULL-terminated c string.
  * destinationSize IN: Actual buffer size of destination[].
  *                     Pass sizeof(destination) here for fixed size char arrays.
  */
-void dcgmStrncpy(char *destination, const char *source, size_t destinationSize);
+bool dcgmStrncpy(char *destination, const char *source, size_t destinationSize);
 
 /*****************************************************************************/
 /*

--- a/common/tests/StringHelpersTests.cpp
+++ b/common/tests/StringHelpersTests.cpp
@@ -71,3 +71,21 @@ TEST_CASE("ParseRangeString")
     }
     CHECK(indices[16] == 24);
 }
+
+TEST_CASE("dcgmStrncpy differing src sizes")
+{
+    using namespace DcgmNs;
+    const std::string c_strSmallerThanBuffer = "TestString1";
+    const std::string c_strSizeOfBuffer = "TestString2TestString2!!";
+    const std::string c_strLargerThanBuffer = "TestString3TestString3TestString3";
+    std::vector<char> vDestination(25);
+    
+    REQUIRE(true == dcgmStrncpy(vDestination.data(), c_strSmallerThanBuffer.c_str(), vDestination.size()));
+    REQUIRE(c_strSmallerThanBuffer == std::string(vDestination.begin(), vDestination.end()).c_str());
+
+    REQUIRE(true == dcgmStrncpy(vDestination.data(), c_strSizeOfBuffer.c_str(), vDestination.size()));
+    REQUIRE(c_strSizeOfBuffer == std::string(vDestination.begin(), vDestination.end()).c_str());
+
+    REQUIRE(false == dcgmStrncpy(vDestination.data(), c_strLargerThanBuffer.c_str(), vDestination.size()));
+    REQUIRE(c_strLargerThanBuffer != std::string(vDestination.begin(), vDestination.end()).c_str());
+}

--- a/dcgmi/DcgmiTest.cpp
+++ b/dcgmi/DcgmiTest.cpp
@@ -243,7 +243,10 @@ dcgmReturn_t DcgmiTest::HelperInitFieldValue(dcgmInjectFieldValue_t &injectField
             injectFieldValue.value.i64 = atol(injectValue.c_str());
             break;
         case DCGM_FT_STRING:
-            dcgmStrncpy(injectFieldValue.value.str, injectValue.c_str(), sizeof(injectFieldValue.value.str));
+            if (false == dcgmStrncpy(injectFieldValue.value.str, injectValue.c_str(), sizeof(injectFieldValue.value.str)))
+            {
+                log_debug("String overflow error for the requested injectValue.");
+            }
             break;
         case DCGM_FT_DOUBLE:
             injectFieldValue.value.dbl = atof(injectValue.c_str());

--- a/dcgmlib/src/DcgmApi.cpp
+++ b/dcgmlib/src/DcgmApi.cpp
@@ -590,7 +590,12 @@ dcgmReturn_t helperGroupGetInfo(dcgmHandle_t pDcgmHandle,
         return (dcgmReturn_t)msg.gi.cmdRet;
     }
 
-    dcgmStrncpy(pDcgmGroupInfo->groupName, msg.gi.groupInfo.groupName, sizeof(pDcgmGroupInfo->groupName));
+    if (false == dcgmStrncpy(pDcgmGroupInfo->groupName,
+                            msg.gi.groupInfo.groupName,
+                            sizeof(pDcgmGroupInfo->groupName)))
+    {
+        DCGM_LOG_ERROR << "String overflow error for the requested groupInfo groupName field.";
+    }
 
     if (hostEngineTimestamp)
     {
@@ -917,18 +922,12 @@ dcgmReturn_t helperDeviceGetAttributes(dcgmHandle_t pDcgmHandle, int gpuId, dcgm
 
             case DCGM_FI_DEV_UUID:
             {
-                size_t length;
-                length = strlen(fv->value.str);
-                if (length + 1 > sizeof(pDcgmDeviceAttr->identifiers.uuid))
+                if (false == dcgmStrncpy(pDcgmDeviceAttr->identifiers.uuid,
+                                        fv->value.str,
+                                        sizeof(pDcgmDeviceAttr->identifiers.uuid)))
                 {
-                    log_error("String overflow error for the requested UUID field");
-                    dcgmStrncpy(
-                        pDcgmDeviceAttr->identifiers.uuid, DCGM_STR_BLANK, sizeof(pDcgmDeviceAttr->identifiers.uuid));
-                }
-                else
-                {
-                    dcgmStrncpy(
-                        pDcgmDeviceAttr->identifiers.uuid, fv->value.str, sizeof(pDcgmDeviceAttr->identifiers.uuid));
+                    log_error("String overflow error for the requested UUID field.");
+                    dcgmStrncpy(pDcgmDeviceAttr->identifiers.uuid, DCGM_STR_BLANK, sizeof(pDcgmDeviceAttr->identifiers.uuid));
                 }
 
                 break;
@@ -936,18 +935,12 @@ dcgmReturn_t helperDeviceGetAttributes(dcgmHandle_t pDcgmHandle, int gpuId, dcgm
 
             case DCGM_FI_DEV_VBIOS_VERSION:
             {
-                size_t length;
-                length = strlen(fv->value.str);
-                if (length + 1 > sizeof(pDcgmDeviceAttr->identifiers.vbios))
+                if (false == dcgmStrncpy(pDcgmDeviceAttr->identifiers.vbios, 
+                                        fv->value.str,
+                                        sizeof(pDcgmDeviceAttr->identifiers.vbios)))
                 {
-                    log_error("String overflow error for the requested VBIOS field");
-                    dcgmStrncpy(
-                        pDcgmDeviceAttr->identifiers.vbios, DCGM_STR_BLANK, sizeof(pDcgmDeviceAttr->identifiers.vbios));
-                }
-                else
-                {
-                    dcgmStrncpy(
-                        pDcgmDeviceAttr->identifiers.vbios, fv->value.str, sizeof(pDcgmDeviceAttr->identifiers.vbios));
+                    log_error("String overflow error for the requested VBIOS field.");
+                    dcgmStrncpy(pDcgmDeviceAttr->identifiers.vbios, DCGM_STR_BLANK, sizeof(pDcgmDeviceAttr->identifiers.vbios));
                 }
 
                 break;
@@ -955,19 +948,13 @@ dcgmReturn_t helperDeviceGetAttributes(dcgmHandle_t pDcgmHandle, int gpuId, dcgm
 
             case DCGM_FI_DEV_INFOROM_IMAGE_VER:
             {
-                size_t length;
-                length = strlen(fv->value.str);
-                if (length + 1 > sizeof(pDcgmDeviceAttr->identifiers.inforomImageVersion))
+                if (false == dcgmStrncpy(pDcgmDeviceAttr->identifiers.inforomImageVersion,
+                                        fv->value.str, 
+                                        sizeof(pDcgmDeviceAttr->identifiers.inforomImageVersion)))
                 {
-                    log_error("String overflow error for the requested Inforom field");
-                    dcgmStrncpy(pDcgmDeviceAttr->identifiers.inforomImageVersion,
-                                DCGM_STR_BLANK,
-                                sizeof(pDcgmDeviceAttr->identifiers.inforomImageVersion));
-                }
-                else
-                {
-                    dcgmStrncpy(pDcgmDeviceAttr->identifiers.inforomImageVersion,
-                                fv->value.str,
+                    log_error("String overflow error for the requested Inforom field.");
+                    dcgmStrncpy(pDcgmDeviceAttr->identifiers.inforomImageVersion, 
+                                DCGM_STR_BLANK, 
                                 sizeof(pDcgmDeviceAttr->identifiers.inforomImageVersion));
                 }
 
@@ -976,19 +963,13 @@ dcgmReturn_t helperDeviceGetAttributes(dcgmHandle_t pDcgmHandle, int gpuId, dcgm
 
             case DCGM_FI_DEV_BRAND:
             {
-                size_t length;
-                length = strlen(fv->value.str);
-                if (length + 1 > sizeof(pDcgmDeviceAttr->identifiers.brandName))
+                if (false == dcgmStrncpy(pDcgmDeviceAttr->identifiers.brandName, 
+                                        fv->value.str, 
+                                        sizeof(pDcgmDeviceAttr->identifiers.brandName)))
                 {
-                    log_error("String overflow error for the requested brand name field");
+                    log_error("String overflow error for the requested brand name field.");
                     dcgmStrncpy(pDcgmDeviceAttr->identifiers.brandName,
                                 DCGM_STR_BLANK,
-                                sizeof(pDcgmDeviceAttr->identifiers.brandName));
-                }
-                else
-                {
-                    dcgmStrncpy(pDcgmDeviceAttr->identifiers.brandName,
-                                fv->value.str,
                                 sizeof(pDcgmDeviceAttr->identifiers.brandName));
                 }
 
@@ -997,19 +978,13 @@ dcgmReturn_t helperDeviceGetAttributes(dcgmHandle_t pDcgmHandle, int gpuId, dcgm
 
             case DCGM_FI_DEV_NAME:
             {
-                size_t length;
-                length = strlen(fv->value.str);
-                if (length + 1 > sizeof(pDcgmDeviceAttr->identifiers.deviceName))
+                if(false == dcgmStrncpy(pDcgmDeviceAttr->identifiers.deviceName, 
+                                        fv->value.str, 
+                                        sizeof(pDcgmDeviceAttr->identifiers.deviceName)))
                 {
-                    log_error("String overflow error for the requested device name field");
-                    dcgmStrncpy(pDcgmDeviceAttr->identifiers.deviceName,
+                    log_error("String overflow error for the requested device name field.");
+                    dcgmStrncpy(pDcgmDeviceAttr->identifiers.deviceName, 
                                 DCGM_STR_BLANK,
-                                sizeof(pDcgmDeviceAttr->identifiers.deviceName));
-                }
-                else
-                {
-                    dcgmStrncpy(pDcgmDeviceAttr->identifiers.deviceName,
-                                fv->value.str,
                                 sizeof(pDcgmDeviceAttr->identifiers.deviceName));
                 }
 
@@ -1018,20 +993,12 @@ dcgmReturn_t helperDeviceGetAttributes(dcgmHandle_t pDcgmHandle, int gpuId, dcgm
 
             case DCGM_FI_DEV_SERIAL:
             {
-                size_t length;
-                length = strlen(fv->value.str);
-                if (length + 1 > sizeof(pDcgmDeviceAttr->identifiers.serial))
+                if(false == dcgmStrncpy(pDcgmDeviceAttr->identifiers.serial,
+                                        fv->value.str, 
+                                        sizeof(pDcgmDeviceAttr->identifiers.serial)))
                 {
                     log_error("String overflow error for the requested serial field");
-                    dcgmStrncpy(pDcgmDeviceAttr->identifiers.serial,
-                                DCGM_STR_BLANK,
-                                sizeof(pDcgmDeviceAttr->identifiers.serial));
-                }
-                else
-                {
-                    dcgmStrncpy(pDcgmDeviceAttr->identifiers.serial,
-                                fv->value.str,
-                                sizeof(pDcgmDeviceAttr->identifiers.serial));
+                    dcgmStrncpy(pDcgmDeviceAttr->identifiers.serial, DCGM_STR_BLANK, sizeof(pDcgmDeviceAttr->identifiers.serial));
                 }
 
                 break;
@@ -1039,20 +1006,12 @@ dcgmReturn_t helperDeviceGetAttributes(dcgmHandle_t pDcgmHandle, int gpuId, dcgm
 
             case DCGM_FI_DEV_PCI_BUSID:
             {
-                size_t length;
-                length = strlen(fv->value.str);
-                if (length + 1 > sizeof(pDcgmDeviceAttr->identifiers.pciBusId))
+                if(false == dcgmStrncpy(pDcgmDeviceAttr->identifiers.pciBusId,
+                                        fv->value.str,
+                                        sizeof(pDcgmDeviceAttr->identifiers.pciBusId)))
                 {
                     log_error("String overflow error for the requested serial field");
-                    dcgmStrncpy(pDcgmDeviceAttr->identifiers.pciBusId,
-                                DCGM_STR_BLANK,
-                                sizeof(pDcgmDeviceAttr->identifiers.pciBusId));
-                }
-                else
-                {
-                    dcgmStrncpy(pDcgmDeviceAttr->identifiers.pciBusId,
-                                fv->value.str,
-                                sizeof(pDcgmDeviceAttr->identifiers.pciBusId));
+                    dcgmStrncpy(pDcgmDeviceAttr->identifiers.pciBusId, DCGM_STR_BLANK, sizeof(pDcgmDeviceAttr->identifiers.pciBusId));
                 }
 
                 break;
@@ -1120,22 +1079,15 @@ dcgmReturn_t helperDeviceGetAttributes(dcgmHandle_t pDcgmHandle, int gpuId, dcgm
 
             case DCGM_FI_DRIVER_VERSION:
             {
-                size_t length;
-                length = strlen(fv->value.str);
-                if (length + 1 > sizeof(pDcgmDeviceAttr->identifiers.driverVersion))
+                if(false == dcgmStrncpy(pDcgmDeviceAttr->identifiers.driverVersion,
+                                        fv->value.str, 
+                                        sizeof(pDcgmDeviceAttr->identifiers.driverVersion)))
                 {
                     log_error("String overflow error for the requested driver version field");
-                    dcgmStrncpy(pDcgmDeviceAttr->identifiers.driverVersion,
-                                DCGM_STR_BLANK,
+                    dcgmStrncpy(pDcgmDeviceAttr->identifiers.driverVersion, 
+                                DCGM_STR_BLANK, 
                                 sizeof(pDcgmDeviceAttr->identifiers.driverVersion));
                 }
-                else
-                {
-                    dcgmStrncpy(pDcgmDeviceAttr->identifiers.driverVersion,
-                                fv->value.str,
-                                sizeof(pDcgmDeviceAttr->identifiers.driverVersion));
-                }
-
                 break;
             }
 
@@ -1580,32 +1532,22 @@ dcgmReturn_t helperVgpuInstanceGetAttributes(dcgmHandle_t pDcgmHandle,
         {
             case DCGM_FI_DEV_VGPU_VM_ID:
             {
-                size_t length;
-                length = strlen(fv->value.str);
-                if (length + 1 > sizeof(pDcgmVgpuInstanceAttr->vmId))
+                if (false == dcgmStrncpy(pDcgmVgpuInstanceAttr->vmId, fv->value.str, sizeof(pDcgmVgpuInstanceAttr->vmId)))
                 {
                     log_error("String overflow error for the requested vGPU instance VM ID field");
                     dcgmStrncpy(pDcgmVgpuInstanceAttr->vmId, DCGM_STR_BLANK, sizeof(pDcgmVgpuInstanceAttr->vmId));
-                }
-                else
-                {
-                    dcgmStrncpy(pDcgmVgpuInstanceAttr->vmId, fv->value.str, sizeof(pDcgmVgpuInstanceAttr->vmId));
                 }
                 break;
             }
 
             case DCGM_FI_DEV_VGPU_VM_NAME:
             {
-                size_t length;
-                length = strlen(fv->value.str);
-                if (length + 1 > sizeof(pDcgmVgpuInstanceAttr->vmName))
+                if(false == dcgmStrncpy(pDcgmVgpuInstanceAttr->vmName, 
+                                        fv->value.str, 
+                                        sizeof(pDcgmVgpuInstanceAttr->vmName)))
                 {
                     log_error("String overflow error for the requested vGPU instance VM name field");
                     dcgmStrncpy(pDcgmVgpuInstanceAttr->vmName, DCGM_STR_BLANK, sizeof(pDcgmVgpuInstanceAttr->vmName));
-                }
-                else
-                {
-                    dcgmStrncpy(pDcgmVgpuInstanceAttr->vmName, fv->value.str, sizeof(pDcgmVgpuInstanceAttr->vmName));
                 }
                 break;
             }
@@ -1616,38 +1558,24 @@ dcgmReturn_t helperVgpuInstanceGetAttributes(dcgmHandle_t pDcgmHandle,
 
             case DCGM_FI_DEV_VGPU_UUID:
             {
-                size_t length;
-                length = strlen(fv->value.str);
-                if (length + 1 > sizeof(pDcgmVgpuInstanceAttr->vgpuUuid))
+                if(false == dcgmStrncpy(pDcgmVgpuInstanceAttr->vgpuUuid,
+                                        fv->value.str,
+                                        sizeof(pDcgmVgpuInstanceAttr->vgpuUuid)))
                 {
                     log_error("String overflow error for the requested vGPU instance UUID field");
-                    dcgmStrncpy(
-                        pDcgmVgpuInstanceAttr->vgpuUuid, DCGM_STR_BLANK, sizeof(pDcgmVgpuInstanceAttr->vgpuUuid));
-                }
-                else
-                {
-                    dcgmStrncpy(
-                        pDcgmVgpuInstanceAttr->vgpuUuid, fv->value.str, sizeof(pDcgmVgpuInstanceAttr->vgpuUuid));
+                    dcgmStrncpy(pDcgmVgpuInstanceAttr->vgpuUuid, DCGM_STR_BLANK, sizeof(pDcgmVgpuInstanceAttr->vgpuUuid));
                 }
                 break;
             }
 
             case DCGM_FI_DEV_VGPU_DRIVER_VERSION:
             {
-                size_t length;
-                length = strlen(fv->value.str);
-                if (length + 1 > sizeof(pDcgmVgpuInstanceAttr->vgpuDriverVersion))
+                if(false == dcgmStrncpy(pDcgmVgpuInstanceAttr->vgpuDriverVersion,
+                                        fv->value.str,
+                                        sizeof(pDcgmVgpuInstanceAttr->vgpuDriverVersion)))
                 {
                     log_error("String overflow error for the requested vGPU instance driver version field");
-                    dcgmStrncpy(pDcgmVgpuInstanceAttr->vgpuDriverVersion,
-                                DCGM_STR_BLANK,
-                                sizeof(pDcgmVgpuInstanceAttr->vgpuDriverVersion));
-                }
-                else
-                {
-                    dcgmStrncpy(pDcgmVgpuInstanceAttr->vgpuDriverVersion,
-                                fv->value.str,
-                                sizeof(pDcgmVgpuInstanceAttr->vgpuDriverVersion));
+                    dcgmStrncpy(pDcgmVgpuInstanceAttr->vgpuDriverVersion, DCGM_STR_BLANK, sizeof(pDcgmVgpuInstanceAttr->vgpuDriverVersion));
                 }
                 break;
             }
@@ -2733,7 +2661,10 @@ dcgmReturn_t tsapiFieldGroupCreate(dcgmHandle_t pDcgmHandle,
     msg.header.version    = dcgm_core_msg_fieldgroup_op_version;
 
     msg.info.fg.version = dcgmFieldGroupInfo_version;
-    dcgmStrncpy(msg.info.fg.fieldGroupName, fieldGroupName, sizeof(msg.info.fg.fieldGroupName) - 1);
+    if(false == dcgmStrncpy(msg.info.fg.fieldGroupName, fieldGroupName, sizeof(msg.info.fg.fieldGroupName) - 1))
+    {
+        DCGM_LOG_ERROR << "String overflow error for the field grp name.";
+    }
     msg.info.fg.numFieldIds = numFieldIds;
     memcpy(msg.info.fg.fieldIds, fieldIds, sizeof(fieldIds[0]) * numFieldIds);
 

--- a/dcgmlib/src/DcgmCacheManager.cpp
+++ b/dcgmlib/src/DcgmCacheManager.cpp
@@ -9045,9 +9045,12 @@ dcgmReturn_t DcgmCacheManager::BufferOrCacheLatestGpuValue(dcgmcm_update_thread_
             {
                 vgpuProcessUtilInfo[i + 1].vgpuProcessUtilInfo.vgpuId = vgpuProcessUtilization[i].vgpuInstance;
                 vgpuProcessUtilInfo[i + 1].pid                        = vgpuProcessUtilization[i].pid;
-                dcgmStrncpy(vgpuProcessUtilInfo[i + 1].processName,
-                            vgpuProcessUtilization[i].processName,
-                            DCGM_VGPU_NAME_BUFFER_SIZE);
+                if(false == dcgmStrncpy(vgpuProcessUtilInfo[i + 1].processName,
+                                        vgpuProcessUtilization[i].processName,
+                                        DCGM_VGPU_NAME_BUFFER_SIZE))
+                {
+                    log_error("String overflow error for the vgpu proces name.");
+                }
                 vgpuProcessUtilInfo[i + 1].smUtil  = vgpuProcessUtilization[i].smUtil;
                 vgpuProcessUtilInfo[i + 1].memUtil = vgpuProcessUtilization[i].memUtil;
                 vgpuProcessUtilInfo[i + 1].encUtil = vgpuProcessUtilization[i].encUtil;

--- a/dcgmlib/src/DcgmFieldGroup.cpp
+++ b/dcgmlib/src/DcgmFieldGroup.cpp
@@ -330,7 +330,13 @@ dcgmReturn_t DcgmFieldGroupManager::PopulateFieldGroupInfo(dcgmFieldGroupInfo_t 
             fieldGroupInfo->fieldIds[i] = fieldIds[i];
         }
     }
-    dcgmStrncpy(fieldGroupInfo->fieldGroupName, fieldGrpObj->GetName().c_str(), sizeof(fieldGroupInfo->fieldGroupName));
+
+    if(false == dcgmStrncpy(fieldGroupInfo->fieldGroupName,
+                            fieldGrpObj->GetName().c_str(),
+                            sizeof(fieldGroupInfo->fieldGroupName)))
+    {
+        log_error("String overflow error for the field grp obj.");
+    }
 
     Unlock();
     return DCGM_ST_OK;
@@ -365,9 +371,13 @@ dcgmReturn_t DcgmFieldGroupManager::PopulateFieldGroupGetAll(dcgmAllFieldGroup_t
                 allGroupInfo->fieldGroups[allGroupInfo->numFieldGroups].fieldIds[i] = fieldIds[i];
             }
         }
-        dcgmStrncpy(allGroupInfo->fieldGroups[allGroupInfo->numFieldGroups].fieldGroupName,
-                    fieldGrpObj->GetName().c_str(),
-                    sizeof(allGroupInfo->fieldGroups[allGroupInfo->numFieldGroups].fieldGroupName));
+
+        if(false == dcgmStrncpy(allGroupInfo->fieldGroups[allGroupInfo->numFieldGroups].fieldGroupName,
+                                fieldGrpObj->GetName().c_str(), 
+                                sizeof(allGroupInfo->fieldGroups[allGroupInfo->numFieldGroups].fieldGroupName)))
+        {
+            log_error("String overflow error for the field grp obj name.");
+        }
 
         allGroupInfo->fieldGroups[allGroupInfo->numFieldGroups].fieldGroupId
             = (dcgmFieldGrp_t)(intptr_t)fieldGrpObj->GetId();

--- a/dcgmlib/src/dcgm_fields.cpp
+++ b/dcgmlib/src/dcgm_fields.cpp
@@ -162,7 +162,10 @@ static int DcgmFieldsPopulateOneFieldWithFormatting(unsigned short fieldId,
     fieldMeta->fieldId   = fieldId;
     fieldMeta->fieldType = fieldType;
     fieldMeta->size      = size;
-    dcgmStrncpy(fieldMeta->tag, tag, sizeof(fieldMeta->tag));
+    if (false == dcgmStrncpy(fieldMeta->tag, tag, sizeof(fieldMeta->tag)))
+    {
+        DCGM_LOG_ERROR << "String overflow error for the requested tag.";
+    }
     fieldMeta->scope       = scope;
     fieldMeta->nvmlFieldId = nvmlFieldId;
 
@@ -174,8 +177,16 @@ static int DcgmFieldsPopulateOneFieldWithFormatting(unsigned short fieldId,
     }
     memset(fieldMeta->valueFormat, 0, sizeof(*fieldMeta->valueFormat));
 
-    dcgmStrncpy(fieldMeta->valueFormat->shortName, shortName, sizeof(fieldMeta->valueFormat->shortName));
-    dcgmStrncpy(fieldMeta->valueFormat->unit, unit, sizeof(fieldMeta->valueFormat->unit));
+    if (false == dcgmStrncpy(fieldMeta->valueFormat->shortName, shortName, sizeof(fieldMeta->valueFormat->shortName)))
+    {
+        DCGM_LOG_ERROR << "String overflow error for the requested shortName.";
+    }
+
+    if (false == dcgmStrncpy(fieldMeta->valueFormat->unit, unit, sizeof(fieldMeta->valueFormat->unit)))
+    {
+        DCGM_LOG_ERROR << "String overflow error for the requested unit.";
+    }
+
     fieldMeta->valueFormat->width = width;
     fieldMeta->entityLevel        = entityLevel;
 


### PR DESCRIPTION
Hello my name is Everett Badeaux. I just wanted to make the pull request to improve the performance and functionality of your string copy command. I applied for JR1974024. Lets connect! I’m on Linkedin & email is on my github.


Here are a few of the performance benefits of the new implementation:

- In your implementation strncpy would continue to copy null bytes until it wrote the amount specified destination size. This is not needed. With memccpy execution will immediately stop once the null terminator is encountered. This can be a great performance benefit if the src is exponentially larger than the destination size
- You also had no way of knowing if the source buffer was larger than the destination buffer. Now false will be returned if the null terminating character is not encountered otherwise true indicating successful copy.
- Keeps your old implementation that if the source is not null terminated we will add at len -1 position
- Unit tests
