### PR TITLE
Add support for IPv6

### DIFF
--- a/common/transport/DcgmIpc.cpp
+++ b/common/transport/DcgmIpc.cpp
@@ -275,7 +275,10 @@ static int SetNonBlocking(int fd)
 /*****************************************************************************/
 dcgmReturn_t DcgmIpc::InitTCPListenerSocket()
 {
-    struct sockaddr_in listenAddr;
+    struct sockaddr_in listenAddr4;
+    struct sockaddr_in6 listenAddr6;
+    struct sockaddr_storage listenAddr;
+    int ipv6Only;
     int reuseAddrOn;
 
     ASSERT_IS_IPC_THREAD;
@@ -286,12 +289,56 @@ dcgmReturn_t DcgmIpc::InitTCPListenerSocket()
         return DCGM_ST_OK;
     }
 
+    memset(&listenAddr4, 0, sizeof(listenAddr4));
+    listenAddr4.sin_family = AF_INET;
+    listenAddr4.sin_port   = htons(m_tcpParameters.value().port);
+
+    memset(&listenAddr6, 0, sizeof(listenAddr6));
+    listenAddr6.sin6_family = AF_INET6;
+    listenAddr6.sin6_port   = htons(m_tcpParameters.value().port);
+
+    if (m_tcpParameters.value().bindIPAddress.size() > 0)
+    {
+        if (inet_aton(m_tcpParameters.value().bindIPAddress.c_str(), &listenAddr4.sin_addr) == 1)
+        {
+            memcpy(&listenAddr, &listenAddr4, std::min(sizeof(listenAddr4), sizeof(listenAddr)));
+        }
+        else if (inet_pton(AF_INET6, m_tcpParameters.value().bindIPAddress.c_str(), &listenAddr6.sin6_addr) == 1)
+        {
+            memcpy(&listenAddr, &listenAddr6, std::min(sizeof(listenAddr6), sizeof(listenAddr)));
+        }
+        else
+        {
+            DCGM_LOG_ERROR << "Unable to convert \"" << m_tcpParameters.value().bindIPAddress
+                           << "\" to a network address.";
+            return DCGM_ST_GENERIC_ERROR;
+        }
+    }
+    else
+    {
+        /* Bind to all interfaces (IPv4 and IPv6) */
+        listenAddr6.sin6_addr = in6addr_any;
+        memcpy(&listenAddr, &listenAddr6, std::min(sizeof(listenAddr6), sizeof(listenAddr)));
+    }
+
     /* Create our listening socket. */
-    m_tcpListenSocketFd = socket(AF_INET, SOCK_STREAM, 0);
+    m_tcpListenSocketFd = socket(listenAddr.ss_family, SOCK_STREAM, 0);
     if (m_tcpListenSocketFd < 0)
     {
         DCGM_LOG_ERROR << "ERROR: socket creation failed";
         return DCGM_ST_GENERIC_ERROR;
+    }
+
+    if (listenAddr.ss_family == AF_INET6 && listenAddr6.sin6_addr.s6_addr == in6addr_any.s6_addr)
+    {
+        ipv6Only = 0;
+        if (setsockopt(m_tcpListenSocketFd, IPPROTO_IPV6, IPV6_V6ONLY, &ipv6Only, sizeof(ipv6Only)))
+        {
+            DCGM_LOG_ERROR << "ERROR: setsockopt(IPV6_V6ONLY) failed. errno " << errno;
+            close(m_tcpListenSocketFd);
+            m_tcpListenSocketFd = -1;
+            return DCGM_ST_GENERIC_ERROR;
+        }
     }
 
     reuseAddrOn = 1;
@@ -303,24 +350,6 @@ dcgmReturn_t DcgmIpc::InitTCPListenerSocket()
         return DCGM_ST_GENERIC_ERROR;
     }
 
-    memset(&listenAddr, 0, sizeof(listenAddr));
-    listenAddr.sin_family      = AF_INET;
-    listenAddr.sin_addr.s_addr = INADDR_ANY;
-
-    if (m_tcpParameters.value().bindIPAddress.size() > 0)
-    {
-        /* Convert mSocketPath to a number in network byte order */
-        if (!inet_aton(m_tcpParameters.value().bindIPAddress.c_str(), &listenAddr.sin_addr))
-        {
-            DCGM_LOG_ERROR << "Unable to convert \"" << m_tcpParameters.value().bindIPAddress
-                           << "\" to a network address.";
-            close(m_tcpListenSocketFd);
-            m_tcpListenSocketFd = -1;
-            return DCGM_ST_GENERIC_ERROR;
-        }
-    }
-
-    listenAddr.sin_port = htons(m_tcpParameters.value().port);
     if (bind(m_tcpListenSocketFd, (struct sockaddr *)&listenAddr, sizeof(listenAddr)) < 0)
     {
         DCGM_LOG_ERROR << "bind failed. port " << m_tcpParameters.value().port << ", address "
@@ -579,8 +608,22 @@ void DcgmIpc::ConnectTcpAsyncImpl(DcgmIpcConnectTcp &tcpConnect)
     bufferevent_setcb(bev, DcgmIpc::StaticReadCB, NULL, DcgmIpc::StaticEventCB, this);
     bufferevent_enable(bev, EV_READ | EV_WRITE);
 
+    /* Allow IPv6 IPs to override family */
+    char buf[16];
+    sa_family_t family = AF_INET;
+    std::string str = tcpConnect.m_hostname;
+    if (str.size() >= 3 && str[0] == '[' && str[str.size() - 1] == ']')
+    {
+        tcpConnect.m_hostname = str.substr(1, str.size() - 2);
+    }
+    memset(buf, 0, sizeof(buf));
+    if (inet_pton(AF_INET6, tcpConnect.m_hostname.c_str(), buf) > 0)
+    {
+        family = AF_INET6;
+    }
+
     int ret = bufferevent_socket_connect_hostname(
-        bev, m_dnsBase, AF_INET, tcpConnect.m_hostname.c_str(), tcpConnect.m_port);
+        bev, m_dnsBase, family, tcpConnect.m_hostname.c_str(), tcpConnect.m_port);
     if (0 != ret)
     {
         RemoveConnectionByBev(bev);

--- a/dcgmlib/src/DcgmClientHandler.cpp
+++ b/dcgmlib/src/DcgmClientHandler.cpp
@@ -229,8 +229,9 @@ dcgmReturn_t DcgmClientHandler::GetConnHandleForHostEngine(const char *identifie
     unsigned int portNumber = 0;
     char *p                 = NULL;
 
-    if (!addressIsUnixSocket)
-        p = strchr(&identifierTemp[0], ':');
+    // For an IPv4 address, try separating the port number from the IP address
+    if (!addressIsUnixSocket && identifierTemp.size() >= 2 && identifierTemp[identifierTemp.size()-2] != ']')
+        p = strrchr(&identifierTemp[0], ':');
 
     if (p == NULL)
     {

--- a/hostengine/src/HostEngineCommandLine.cpp
+++ b/hostengine/src/HostEngineCommandLine.cpp
@@ -146,6 +146,10 @@ std::string ParseBindIp(std::string const &value)
     {
         return ""s;
     }
+    /* If the value is an IPv6 address, then we need to remove [] from it */
+    if (value.size() >= 3 && value[0] == '[' && value[value.size() - 1] == ']') {
+        return value.substr(1, value.size() - 2);
+    }
     return value;
 }
 


### PR DESCRIPTION
Fixes #150 

I've added IPv6 support to Hostengine and dcgmi CLI while not changing/breaking any existing functionality. 

## Hostengine now supports binding to an IPv6 address

Start hostnegine:
```
$ nv-hostengine -b [::1] --log-level debug
Started host engine version 3.3.6 using port number: 5555
```
Confirm using lsof:
```
$ sudo lsof -i :5555
COMMAND       PID USER   FD   TYPE     DEVICE SIZE/OFF NODE NAME
nv-hosten 2004760 root   47u  IPv6 3165553609      0t0  TCP localhost:personal-agent (LISTEN)
```
Connect using dcgmi without port:
```
$ dcgmi discovery -l --host [::1]
8 GPUs found.
+--------+----------------------------------------------------------------------+
| GPU ID | Device Information                                                   |
+--------+----------------------------------------------------------------------+
| 0      | Name: NVIDIA PG509-210                                               |
|        | PCI Bus ID: 00000000:04:00.0                                         |
|        | Device UUID: GPU-de6a7a6a-776e-e6e2-bd3d-d8114ccf6db2                |
```
Connect using dcgmi with port:
```
$ dcgmi discovery -l --host [::1]:5555
8 GPUs found.
+--------+----------------------------------------------------------------------+
| GPU ID | Device Information                                                   |
+--------+----------------------------------------------------------------------+
| 0      | Name: NVIDIA PG509-210                                               |
|        | PCI Bus ID: 00000000:04:00.0                                         |
|        | Device UUID: GPU-de6a7a6a-776e-e6e2-bd3d-d8114ccf6db2                |
```

## Hostengine now supports both IPv4 and IPv6 connections
Start hostnegine:
```
$ nv-hostengine -b ALL --log-level debug
Started host engine version 3.3.6 using port number: 5555
```
Confirm using lsof:
```
$ sudo lsof -i :5555
COMMAND       PID USER   FD   TYPE     DEVICE SIZE/OFF NODE NAME
nv-hosten 2478925 root   47u  IPv6 3173352315      0t0  TCP *:personal-agent (LISTEN)
```
Connect using dcgmi on IPv4:
```
$ dcgmi discovery -l
8 GPUs found.
+--------+----------------------------------------------------------------------+
| GPU ID | Device Information                                                   |
+--------+----------------------------------------------------------------------+
| 0      | Name: NVIDIA PG509-210                                               |
|        | PCI Bus ID: 00000000:04:00.0                                         |
|        | Device UUID: GPU-de6a7a6a-776e-e6e2-bd3d-d8114ccf6db2                |
```
Connect using dcgmi on IPv6:
```
$ dcgmi discovery -l --host [::1]
8 GPUs found.
+--------+----------------------------------------------------------------------+
| GPU ID | Device Information                                                   |
+--------+----------------------------------------------------------------------+
| 0      | Name: NVIDIA PG509-210                                               |
|        | PCI Bus ID: 00000000:04:00.0                                         |
|        | Device UUID: GPU-de6a7a6a-776e-e6e2-bd3d-d8114ccf6db2                |
```
## Hostengine default IPv4 functionality is not broken
Start hostnegine:
```
$ nv-hostengine --log-level debug
Started host engine version 3.3.6 using port number: 5555
```
Confirm using lsof:
```
$ sudo lsof -i :5555
COMMAND       PID USER   FD   TYPE     DEVICE SIZE/OFF NODE NAME
nv-hosten 2476116 root   47u  IPv4 3173251779      0t0  TCP localhost:personal-agent (LISTEN)
```
Connect using dcgmi on IPv4:
```
$ dcgmi discovery -l
8 GPUs found.
+--------+----------------------------------------------------------------------+
| GPU ID | Device Information                                                   |
+--------+----------------------------------------------------------------------+
| 0      | Name: NVIDIA PG509-210                                               |
|        | PCI Bus ID: 00000000:04:00.0                                         |
|        | Device UUID: GPU-de6a7a6a-776e-e6e2-bd3d-d8114ccf6db2                |
```
Connect using dcgmi on IPv6 (expected failure):
```
$ dcgmi discovery -l --host [::1]
Error: unable to establish a connection to the specified host: [::1]
Error: Unable to connect to host engine. Host engine connection invalid/disconnected.
```