### PR TITLE
c++: add missing includes

### DIFF
--- a/common/CudaWorker/DcgmDgemm.cpp
+++ b/common/CudaWorker/DcgmDgemm.cpp
@@ -15,6 +15,7 @@
  */
 #include "DcgmDgemm.hpp"
 
+#include <cstdint>
 #include <exception>
 #include <stdexcept>
 

--- a/common/DcgmError.h
+++ b/common/DcgmError.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <sstream>
 #include <string>
 

--- a/common/DcgmStringHelpers.cpp
+++ b/common/DcgmStringHelpers.cpp
@@ -15,6 +15,7 @@
  */
 #include "DcgmStringHelpers.h"
 
+#include <algorithm>
 #include <cstring>
 #include <string>
 

--- a/dcgmi/CommandOutputController.cpp
+++ b/dcgmi/CommandOutputController.cpp
@@ -25,6 +25,7 @@
 #include <DcgmStringHelpers.h>
 #include <algorithm>
 #include <cstdarg>
+#include <functional>
 #include <iostream>
 #include <string>
 

--- a/dcgmi/Diag.h
+++ b/dcgmi/Diag.h
@@ -24,6 +24,7 @@
 #define DIAG_H_
 
 #include <optional>
+#include <functional>
 
 #include "Command.h"
 #include "CommandOutputController.h"

--- a/dcgmlib/src/DcgmGpuInstance.cpp
+++ b/dcgmlib/src/DcgmGpuInstance.cpp
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <algorithm>
+
 #include "DcgmGpuInstance.h"
 
 #include <DcgmLogging.h>

--- a/hostengine/src/HostEngineOutput.cpp
+++ b/hostengine/src/HostEngineOutput.cpp
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <limits>
 #include <string_view>
+#include <unordered_map>
 
 namespace
 {

--- a/nvvs/src/NvvsCommon.cpp
+++ b/nvvs/src/NvvsCommon.cpp
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#include <algorithm>
 #include <sstream>
 #include <stdexcept>
 #include <sys/stat.h>

--- a/nvvs/src/TestFramework.cpp
+++ b/nvvs/src/TestFramework.cpp
@@ -25,6 +25,7 @@
 #include <TestFramework.h>
 
 #include <atomic>
+#include <algorithm>
 #include <cerrno>
 #include <cstdio>
 #include <cstdlib>

--- a/sdk/nvidia/nvml/nvml_loader/nvml_loader.cpp
+++ b/sdk/nvidia/nvml/nvml_loader/nvml_loader.cpp
@@ -19,6 +19,7 @@
 #include <dlfcn.h>
 
 #include <atomic>
+#include <cstdlib>
 #include <mutex>
 
 static void *g_nvmlLib                                     = 0;


### PR DESCRIPTION
Otherwise project fails to build from source, with gcc 14.2, std=gnu20
with various errors such as std::<something> is not defined.
