### PR TITLE
fix(build): remove failing dcgmbuild/build.sh step

### DIFF
--- a/dcgmbuild/build.sh
+++ b/dcgmbuild/build.sh
@@ -53,7 +53,6 @@ for ARCHITECTURE in "${ARCHITECTURES[@]}"
 do
   docker compose build dcgm-toolchain-$ARCHITECTURE
   docker compose build dcgmbuild-$ARCHITECTURE
-  docker tag ${REGISTRY:-dcgm}/dcgmbuild:$TAG-$ARCHITECTURE dcgmbuild:$TAG-$ARCHITECTURE
 done
 
 docker image rm dcgm/common-host-software:$TAG


### PR DESCRIPTION
The docker tag step in this script causes it to fail. It appears to be due to the tag not being formatted correctly.

Maybe the tag format should change, but removing the line altogether seems to fix things, so we're trying that here.

Fixes #260 