### PR TITLE
fix: index out of bounds in gpuCounts

### DIFF
--- a/dcgmlib/src/DcgmTopology.cpp
+++ b/dcgmlib/src/DcgmTopology.cpp
@@ -782,7 +782,7 @@ dcgmReturn_t GetActiveNvSwitchNvLinkCountsForAllGpus(const std::vector<dcgm_topo
         return DCGM_ST_INSUFFICIENT_SIZE;
     }
 
-    gpuCounts = {};
+    gpuCounts.assign(gpuInfo.size(), 0);
 
     // Attempt to query through NVML. This is not supported in all drivers so
     // there is a fallback approach below


### PR DESCRIPTION
There is an index out of bound issue that shows up in DcgmTopology when DCGM is installed with dcgm-exporter on systems with more than one GPU. This error only occurs when assertions are enabled (`_GLIBCXX_ASSERTIONS`). The actual invalid access appears to occur on 729 of DcgmTopology.cpp. 

This fix simply resets the gpuCounts vector to a vector of it's original size with values of 0, rather than setting gpuCounts to an empty vector.