### PR TITLE
docs: fix typos and improve accuracy in README.md and contributing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ New dependencies can be added by adding a script in the “scripts” directory
 similar to the existing scripts.
 
 As DCGM needs to support some older Linux distributions on various CPU
-architectures, the image provide custom builds of GCC compilers that produce
+architectures, the image provides custom builds of GCC compilers that produce
 binaries which depend on older versions of the GLibc libraries. The DCGM build
 image will also contain all 3rd party libraries that are precompiled using those
 custom GCC builds.
@@ -79,11 +79,11 @@ building 3 versions of GCC toolset for all supported platforms. Once the image
 has been built, it can be reused to build DCGM.
 
 ### Generating a DCGM build
-Once the build image is created, you can use the run `build.sh` to produce builds. A simple debian build of release (non-debug) code for an x86_64 system can be made with: 
+Once the build image is created, you can run `build.sh` to produce builds. A simple Debian build of release (non-debug) code for an x86_64 system can be made with:
 
 `./build.sh -r --deb`
 
-The rpm will be placed in `_out/Linux-amd64-release/datacenter-gpu-manager_2.1.4_amd64.deb`; it can now be installed as needed. The script includes options for building just the binaries (default), tarballs (--packages), or RPM (--rpm) as well. A complete list of options can been seen using `./build.sh -h`.
+The .deb package will be placed in `_out/Linux-amd64-release/` (e.g. `datacenter-gpu-manager_<version>_amd64.deb`); it can now be installed as needed. The script includes options for building just the binaries (default), tarballs (--packages), or RPM (--rpm) as well. A complete list of options can be seen using `./build.sh -h`.
 
 ### Running the Test Framework
 DCGM includes an extensive test suite that can be run on any system with one or more supported GPUs. After successfully building DCGM tarballs, a `datacenter-gpu-manager-tests` package is created alongside the normal DCGM package. There are multiple ways to run the tests but the most straightforward steps are the following:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -4,7 +4,7 @@ NVIDIA Data Center GPU Manager (DCGM) is a suite of tools for managing and monit
 
 # Architecture
 
-As previously stated, DCGM is a tool used to monitor the health and telemetry of NVIDIAGPUs and their related components. We use a modular design to accomplish this task. The core of DCGM consists of:
+As previously stated, DCGM is a tool used to monitor the health and telemetry of NVIDIA GPUs and their related components. We use a modular design to accomplish this task. The core of DCGM consists of:
  - APIs for interacting with the DCGM agent (nv-hostengine).
  - A cache for the known telemetry.
  - Modules that perform different functions:
@@ -54,7 +54,7 @@ DCGM follows semver best practices, so the nature of the change will determine w
  - Insufficient time: changes that cannot be reviewed in time will be deferred to another release. Similarly, if a change is risky it must be adopted early enough in the release cycle to ensure that it hasn’t caused any regressions. Risky changes submitted later in a release cycle will also be deferred to the next release.
  - Incompleteness: for example, a change that updates C APIs, but doesn’t modify the Python bindings would be considered incomplete.
  - Changes that are not signed cannot be accepted.
- - Code must meet the DCGM coding best practices mentioned in dcgm_best_practices.md, as well as following the style that is checked for by the pre-commit hooks if properly configured. 
+ - Code must meet the DCGM coding best practices mentioned in [coding_best_practices.md](coding_best_practices.md), as well as following the style that is checked for by the pre-commit hooks if properly configured.
 
 ## The Mechanics of Contributing
 1. Create a github issue which explains the change that you desire to make.


### PR DESCRIPTION
## What

Fix several typos, a factual error, a broken internal link, and minor grammar issues in `README.md` and `docs/contributing.md`.

### README.md

| Line | Before | After | Category |
|------|--------|-------|----------|
| 44 | `the image provide custom builds` | `the image provides custom builds` | Grammar (subject-verb agreement) |
| 82 | `you can use the run `build.sh`` | `you can run `build.sh`` | Grammar (duplicate word) |
| 82 | `A simple debian build` | `A simple Debian build` | Style (proper noun) |
| 86 | `The rpm will be placed in …\.deb` | `The .deb package will be placed in` | Factual error (example uses `--deb`, not `--rpm`) |
| 86 | Hardcoded version `2.1.4` in example path | `<version>` placeholder | Accuracy (version is stale) |
| 86 | `can been seen` | `can be seen` | Grammar |

### docs/contributing.md

| Line | Before | After | Category |
|------|--------|-------|----------|
| 7 | `NVIDIAGPUs` | `NVIDIA GPUs` | Missing space |
| 57 | `dcgm_best_practices.md` (plain text, wrong filename) | `[coding_best_practices.md](coding_best_practices.md)` (link, correct filename) | Broken reference |

## Why

- The `The rpm will be placed in …\.deb` sentence is the most impactful: a first-time contributor building with `--deb` gets a path description that says "rpm" and an outdated version number. This is confusing and undermines confidence in the build guide.
- `NVIDIAGPUs` (no space) reads as a single word in the Contributing introduction; browsers and screen readers handle it poorly.
- `dcgm_best_practices.md` does not exist in the repo; the actual file is `coding_best_practices.md`. A reader following the link (once it becomes a hyperlink) or searching for the file would not find it.

## How

All changes are textual — no code, no logic, no tests affected.

## Testing

- `grep -n 'rpm will be placed\|can been\|NVIDIAGPUs\|dcgm_best_practices' README.md docs/contributing.md` returns no results after the patch
- Markdown renders correctly in GitHub preview

## Checklist

- [x] Documentation only — no code changes
- [x] All corrections verified against the actual repo file names and the build.sh output path logic
- [x] No new dependencies