### PR TITLE
diag: rename 'Device IDs' to 'PCI Device IDs' in dcgmi diag output

### DIFF
--- a/dcgmi/Diag.cpp
+++ b/dcgmi/Diag.cpp
@@ -768,7 +768,7 @@ void Diag::HelperDisplayVersionAndDevIds(dcgmDiagResponse_v12 const &response) c
         {
             cmdView.addDisplayParameter(
                 DATA_NAME_TAG,
-                fmt::format("{} Device IDs Detected",
+                fmt::format("{} PCI Device IDs Detected",
                             DcgmFieldsGetEntityGroupString(static_cast<dcgm_field_entity_group_t>(gId))));
             cmdView.addDisplayParameter(DATA_INFO_TAG, str);
             cmdView.display();

--- a/nvvs/include/NvvsJsonStrings.h
+++ b/nvvs/include/NvvsJsonStrings.h
@@ -38,7 +38,7 @@
 #define NVVS_ERROR_SEVERITY   "error_severity"
 #define NVVS_ITERATIONS       "iterations"
 #define NVVS_RESULT           "Overall Result"
-#define NVVS_GPU_DEV_IDS      "GPU Device IDs"
+#define NVVS_GPU_DEV_IDS      "GPU PCI Device IDs"
 #define NVVS_GPU_SERIALS      "GPU Device Serials"
 #define NVVS_DRIVER_VERSION   "Driver Version Detected"
 #define NVVS_AUX_DATA         "aux_data"


### PR DESCRIPTION
## Summary

On multi-GPU systems where every GPU is the same model, `dcgmi diag` displays a
metadata row labelled **"GPU Device IDs Detected"** followed by a list of
identical values (e.g. `3182, 3182, 3182, 3182, 3182, 3182, 3182`).  This is
confusing because the label implies each value uniquely identifies a GPU, when in
reality the values are **PCI device IDs** — a hardware SKU identifier that is
shared across all GPUs of teh same model.

This change renames the label to **"GPU PCI Device IDs Detected"** so that the
output accurately communicates what the values represent.  The corresponding JSON
string constant `NVVS_GPU_DEV_IDS` is also updated for consistency.

### What changed

| File | Change |
|------|--------|
| `dcgmi/Diag.cpp` | Format string updated from `"{} Device IDs Detected"` to `"{} PCI Device IDs Detected"` |
| `nvvs/include/NvvsJsonStrings.h` | `NVVS_GPU_DEV_IDS` updated from `"GPU Device IDs"` to `"GPU PCI Device IDs"` |

### Before / After

**Before:**
```
| GPU Device IDs Detected   | 3182, 3182, 3182, 3182, 3182, 3182, 3182       |
```

**After:**
```
| GPU PCI Device IDs Detected | 3182, 3182, 3182, 3182, 3182, 3182, 3182     |
```

The word "PCI" makes it immediately clear that these are hardware-level
identifiers, and that identical values across GPUs is the expected behaviour for
GPUs of the same model.

Fixes #282