### PR TITLE
Fix dcgmi signal handler

### DIFF
--- a/dcgmi/main_dcgmi.cpp
+++ b/dcgmi/main_dcgmi.cpp
@@ -40,18 +40,22 @@ int InstallCtrlHandler()
 {
     if (signal(SIGHUP, sig_handler) == SIG_ERR)
     {
+        DCGM_LOG_ERROR << "registering SIGHUP failed: " << std::strerror(errno) << std::endl;
         return -1;
     }
     if (signal(SIGINT, sig_handler) == SIG_ERR)
     {
+        DCGM_LOG_ERROR << "registering SIGINT failed: " << std::strerror(errno) << std::endl;
         return -1;
     }
     if (signal(SIGQUIT, sig_handler) == SIG_ERR)
     {
+        DCGM_LOG_ERROR << "registering SIGQUIT failed: " << std::strerror(errno) << std::endl;
         return -1;
     }
     if (signal(SIGTERM, sig_handler) == SIG_ERR)
     {
+        DCGM_LOG_ERROR << "registering SIGTERM failed: " << std::strerror(errno) << std::endl;
         return -1;
     }
 
@@ -75,7 +79,10 @@ int main(int argc, char *argv[])
     DCGM_LOG_INFO << "Initialized DCGMI logger";
 
     // Install the signal handler
-    InstallCtrlHandler();
+    if (InstallCtrlHandler() != 0)
+    {
+        return 1;
+    }
 
     try
     {


### PR DESCRIPTION
Closes #294

## Description

In dcgmi the InstallCtrlHandler silently ignores the return codes in https://github.com/NVIDIA/DCGM/blob/e137795bc755d14fabc0e44c91178a364952cb43/dcgmi/main_dcgmi.cpp#L78.

## Expected Behaviour

The return value of InstallCtrlHandler should be validated. If the installation fails, the code should:

* Log an error with sufficient context.
* Avoid continuing execution in an invalid state.

## Actual Behavior

The function is invoked without checking its return value, so failures are ignored.

## Why This Matters

Failing to install a control handler can prevent proper signal handling (e.g., shutdown, interrupts). Ignoring the result:

* Obscures root causes during failures.
* May lead to resource leaks or improper shutdown.
* Violates standard error-handling practices.