### PR TITLE
Bugfix in dcgmlib: Check per-field nvmlReturn for DCGM_FI_DEV_MEMORY_TEMP_CELSIUS

### DIFF
--- a/dcgmlib/src/DcgmCacheManager.cpp
+++ b/dcgmlib/src/DcgmCacheManager.cpp
@@ -10990,10 +10990,12 @@ dcgmReturn_t DcgmCacheManager::BufferOrCacheLatestGpuValue(dcgmcm_update_thread_
                              : m_nvmlDriver->NvmlDeviceGetFieldValues(safeNvmlDevice, 1, &value);
             if (watchInfo)
                 watchInfo->lastStatus = nvmlReturn;
-            if ((nvmlReturn != NVML_SUCCESS) || (value.value.uiVal > 200))
+            if ((nvmlReturn != NVML_SUCCESS) || (value.nvmlReturn != NVML_SUCCESS) || (value.value.uiVal > 200))
             {
-                AppendEntityInt64(threadCtx, NvmlErrorToInt64Value(nvmlReturn), 0, now, expireTime);
-                return DcgmNs::Utils::NvmlReturnToDcgmReturn(nvmlReturn);
+                nvmlReturn_t nvmlErr = nvmlReturn == NVML_SUCCESS ? value.nvmlReturn : nvmlReturn;
+
+                AppendEntityInt64(threadCtx, NvmlErrorToInt64Value(nvmlErr), 0, now, expireTime);
+                return DcgmNs::Utils::NvmlReturnToDcgmReturn(nvmlErr);
             }
 
             /* Ignore value.valueType, WaR for nvml setting type as double */

--- a/dcgmlib/src/tests/CacheTests.cpp
+++ b/dcgmlib/src/tests/CacheTests.cpp
@@ -1300,6 +1300,80 @@ TEST_CASE("DcgmCacheManager: NVLink TX/RX throughput watches with NVML field inj
     }
 }
 
+TEST_CASE("DcgmCacheManager: DCGM_FI_DEV_MEMORY_TEMP_CELSIUS honors the per-field nvmlReturn")
+{
+    auto restoreEnv = WithNvmlInjectionSkuFile("H200.yaml");
+    if (!restoreEnv)
+    {
+        SKIP("Sku file not found: H200.yaml");
+    }
+
+    DcgmFieldsInit();
+    DcgmNs::Defer deferFields([] { DcgmFieldsTerm(); });
+
+    REQUIRE(nvmlInit_v2() == NVML_SUCCESS);
+    DcgmNs::Defer deferNvml([&] { nvmlShutdown(); });
+
+    DcgmCacheManager cacheManager;
+    /* Initialize in manual mode */
+    REQUIRE(cacheManager.Init(1, 14400.0, true) == DCGM_ST_OK);
+    cacheManager.Start();
+
+    unsigned int constexpr gpuId     = 0;
+    unsigned short constexpr fieldId = DCGM_FI_DEV_MEMORY_TEMP_CELSIUS;
+    DcgmWatcher watcher(DcgmWatcherTypeClient, 5588);
+
+    /* nvmlDeviceGetFieldValues() returns NVML_SUCCESS whenever it populated the array, so the
+       per-value nvmlReturn is what says whether this GPU has a memory temperature sensor. */
+    auto injectMemoryTemp = [&](nvmlReturn_t perFieldReturn, unsigned int uiVal) {
+        nvmlDevice_t nvmlDevice {};
+        REQUIRE(nvmlDeviceGetHandleByIndex(gpuId, &nvmlDevice) == NVML_SUCCESS);
+
+        nvmlFieldValue_t nvmlFv {};
+        nvmlFv.fieldId     = NVML_FI_DEV_MEMORY_TEMP;
+        nvmlFv.scopeId     = 0;
+        nvmlFv.nvmlReturn  = perFieldReturn;
+        nvmlFv.timestamp   = timelib_usecSince1970();
+        nvmlFv.valueType   = NVML_VALUE_TYPE_UNSIGNED_INT;
+        nvmlFv.value.uiVal = uiVal;
+        REQUIRE(nvmlDeviceInjectFieldValue(nvmlDevice, &nvmlFv) == NVML_SUCCESS);
+    };
+
+    bool wereFirstWatcher = false;
+    REQUIRE(
+        cacheManager.AddFieldWatch(DCGM_FE_GPU, gpuId, fieldId, 0, 14400.0, 2, watcher, false, false, wereFirstWatcher)
+        == DCGM_ST_OK);
+    DcgmNs::Defer deferWatch([&] { cacheManager.RemoveFieldWatch(DCGM_FE_GPU, gpuId, fieldId, 0, watcher); });
+
+    SECTION("GIVEN a GPU with no memory temperature sensor THEN the cached value is not supported")
+    {
+        /* What an L4 reports: the call succeeds, the per-field status says the sensor is absent,
+           and the value is left at its zero-initialized state. */
+        injectMemoryTemp(NVML_ERROR_NOT_SUPPORTED, 0);
+
+        REQUIRE(cacheManager.UpdateAllFields(1) == DCGM_ST_OK);
+
+        dcgmcm_sample_t sample {};
+        REQUIRE(cacheManager.GetLatestSample(DCGM_FE_GPU, gpuId, fieldId, &sample, nullptr) == DCGM_ST_OK);
+        CHECK(sample.val.i64 == DCGM_INT64_NOT_SUPPORTED);
+        REQUIRE(cacheManager.FreeSamples(&sample, 1, fieldId) == DCGM_ST_OK);
+    }
+
+    SECTION("GIVEN a GPU with a memory temperature sensor THEN the reading is cached")
+    {
+        unsigned int constexpr expectedTemp = 42;
+        injectMemoryTemp(NVML_SUCCESS, expectedTemp);
+
+        REQUIRE(cacheManager.UpdateAllFields(1) == DCGM_ST_OK);
+
+        dcgmcm_sample_t sample {};
+        REQUIRE(cacheManager.GetLatestSample(DCGM_FE_GPU, gpuId, fieldId, &sample, nullptr) == DCGM_ST_OK);
+        CHECK_FALSE(DCGM_INT64_IS_BLANK(sample.val.i64));
+        CHECK(sample.val.i64 == expectedTemp);
+        REQUIRE(cacheManager.FreeSamples(&sample, 1, fieldId) == DCGM_ST_OK);
+    }
+}
+
 TEST_CASE("DcgmCacheManager::IsGpuMigEnabled & IsMigEnabledAnywhere")
 {
     DcgmCacheManager cacheManager;


### PR DESCRIPTION
## Summary

On L4 nodes, and likely other GPUs that do not support NVML_FI_DEV_MEMORY_TEMP, DCGM reports an invalid "0" value for the temperature. This was raised as a comment [here](https://github.com/NVIDIA/dcgm-exporter/issues/460), potentially impacting other cards. I don't have those cards to test.

nvmlDeviceGetFieldValues returns NVML_SUCCESS when it populates any entry in the values array. In nvml.h, it states that the caller must check each value's own nvmlReturn before reading it, because value is undefined unless that per-field status is NVML_SUCCESS.

## `nvmlDeviceGetFieldValues` API

`nvml.h` states the requirement [in the `nvmlFieldValue_st` struct](https://github.com/NVIDIA/nvidia-settings/blob/0d9c0ea786803e8f5c6783abf89bc3069198a86c/src/nvml.h#L3015-L3016):
```c
    nvmlReturn_t nvmlReturn;    //!< Return code for retrieving this value. This must be checked before looking at value, as value is undefined if nvmlReturn != NVML_SUCCESS
    nvmlValue_t value;          //!< Value for this field. This is only valid if nvmlReturn == NVML_SUCCESS
```

and [in the function call](https://github.com/NVIDIA/nvidia-settings/blob/0d9c0ea786803e8f5c6783abf89bc3069198a86c/src/nvml.h#L10223-L10225):
```c
 *         - \ref NVML_SUCCESS                 if any values in \a values were populated. Note that you must
 *                                             check the nvmlReturn field of each value for each individual
 *                                             status
```

So NVML_SUCCESS means that "the array was populated", not that any values were populated.

The DCGM_FI_DEV_MEMORY_TEMP_CELSIUS handler in BufferOrCacheLatestGpuValue checked only the call's return and then read value.value.uiVal. On a GPU with no memory temperature sensor NVML succeeds and sets the per-field status to NVML_ERROR_NOT_SUPPORTED, leaving value at its zero-initialized state, so the handler cached a literal 0 as a real measurement rather than DCGM_INT64_NOT_SUPPORTED. 

## What is the Result

This results in a valid-looking temperature of 0 C. This is inside the valid domain for a temperature, so an unsupported field is then indistinguishable from a valid reading for every consumer of the field. This shows up when monitoring GPUs with dcgm-exporter on L4 GPUs on GCP.

Using such an L4 GCP node, I reproduced the underlying behavior. Calling NVML directly on an L4 (driver 580.173.02), with no DCGM in the path:
```
  NVML_FI_DEV_MEMORY_TEMP (id 82)
    call nvmlDeviceGetFieldValues -> NVML_SUCCESS
    value.nvmlReturn              -> NVML_ERROR_NOT_SUPPORTED
    value.uiVal                   -> 0
```

nvidia-smi recognizes the missing sensor on the same card:
```
$ nvidia-smi -q -d TEMPERATURE
        GPU Current Temp                               : 57 C
        Memory Current Temp                            : N/A
        Memory Max Operating T.Limit Temp              : N/A
```

## Fix

Check the per-field nvmlReturn for DCGM_FI_DEV_MEMORY_TEMP_CELSIUS.

I made this fix. Afterwards, the previous test scripts using python and using dcgm-exporter showed the expected behavior (missing the time series, not 0 C).

I did not have an obvious way to test the other usages of `nvmlDeviceGetFieldValues`, but it looks like `DCGM_FI_DEV_BOARD_POWER_RAW_WATTS` could have the same error. I did not verify or fix. I didn't have hardware to test that failure on so left it as-is.